### PR TITLE
add !debug to options

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -24,6 +24,7 @@ pkgbase = linux-rust
 	makedepends = python-sphinx
 	makedepends = python-yaml
 	makedepends = texlive-latexextra
+	options = !debug
 	options = !strip
 	source = https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.12.9.tar.xz
 	source = https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.12.9.tar.sign

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -30,7 +30,11 @@ makedepends=(
   python-yaml
   texlive-latexextra
 )
-options=('!strip')
+options=(
+  !debug
+  !strip
+)
+
 _srcname=linux-${pkgver%.*}
 _srctag=v${pkgver%.*}-${pkgver##*.}
 source=(


### PR DESCRIPTION
similar to the arch upstream kernels. See [here](https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/blob/main/PKGBUILD?ref_type=heads#L29) and also in the other PKGBUILDS in the official repos

Sorry for the next PR right away, I just built this package on another machine and realized that it took a lot longer in some "debug" step.